### PR TITLE
Fix error in channelMap indexing for us915 LMIC_disableChannel

### DIFF
--- a/lmic/lmic.c
+++ b/lmic/lmic.c
@@ -774,7 +774,7 @@ bit_t LMIC_setupChannel (u1_t chidx, u4_t freq, u2_t drmap, s1_t band) {
 
 void LMIC_disableChannel (u1_t channel) {
     if( channel < 72+MAX_XCHANNELS )
-        LMIC.channelMap[channel/4] &= ~(1<<(channel&0xF));
+        LMIC.channelMap[channel>>4] &= ~(1<<(channel&0xF));
 }
 
 static u1_t mapChannels (u1_t chpage, u2_t chmap) {


### PR DESCRIPTION
Fix issue #1 by (in effect) dividing by 16 rather than by 4 to get the uint16_t index.
